### PR TITLE
feat: add onError option

### DIFF
--- a/src/http_client.ts
+++ b/src/http_client.ts
@@ -9,9 +9,14 @@ interface LogflareUserOptionsI {
     transforms?: IngestTransformsI
     endpoint?: string
     fromBrowser?: boolean
-    onError?: ((payload: {
-        batch: object[];
-    }, err: Error) => void) | undefined
+    onError?:
+        | ((
+              payload: {
+                  batch: object[]
+              },
+              err: Error
+          ) => void)
+        | undefined
 }
 
 const defaultOptions = {
@@ -40,9 +45,14 @@ class LogflareHttpClient {
     /**
      * onError takes in an optional callback function to handle any errors returned by logflare
      */
-    protected readonly onError?: ((payload: {
-        batch: object[];
-    }, err: Error) => void) | undefined
+    protected readonly onError?:
+        | ((
+              payload: {
+                  batch: object[]
+              },
+              err: Error
+          ) => void)
+        | undefined
 
     public constructor(options: LogflareUserOptionsI) {
         const {sourceToken, apiKey, transforms, endpoint} = options
@@ -100,19 +110,17 @@ class LogflareHttpClient {
 
             return data
         } catch (e) {
-            if (e) {
-                if (e instanceof Error) {
-                    if (e instanceof NetworkError && e.response) {
-                        console.error(
-                            `Logflare API request failed with ${
-                                e.response.status
-                            } status: ${JSON.stringify(e.data)}`
-                        )
-                    } else {
-                        console.error(e.message)
-                    }    
-                    this.onError?.(payload, e)
+            if (e && e instanceof Error) {
+                if (e instanceof NetworkError && e.response) {
+                    console.error(
+                        `Logflare API request failed with ${
+                            e.response.status
+                        } status: ${JSON.stringify(e.data)}`
+                    )
+                } else {
+                    console.error(e.message)
                 }
+                this.onError?.(payload, e)
             }
 
             return e

--- a/src/main.test.js
+++ b/src/main.test.js
@@ -7,10 +7,18 @@ const apiResponseSuccess = {message: "Logged!"}
 
 describe("LogflareHttpClient", () => {
     let httpClient
+    let httpClientOnError
     let nativeFetch
+    let consoleErrorData = []
+    const storeLog = (inputs) => consoleErrorData.push(inputs)
+    const onErrorCallback = jest.fn((payload, err) => {
+        console.error(payload)
+        console.error(err)
+    })
 
     beforeAll(() => {
         nativeFetch = global.fetch
+        console["error"] = jest.fn(storeLog)
     })
 
     beforeEach(() => {
@@ -19,10 +27,17 @@ describe("LogflareHttpClient", () => {
             sourceToken: testSourceToken,
             apiBaseUrl: "http://non-existing.domain",
         })
+        httpClientOnError = new LogflareHttpClient({
+            apiKey: testApiKey,
+            sourceToken: testSourceToken,
+            apiBaseUrl: "http://non-existing.domain",
+            onError: onErrorCallback,
+        })
     })
 
     afterEach(() => {
         global.fetch.mockClear()
+        consoleErrorData = []
     })
 
     afterAll(() => {
@@ -55,12 +70,9 @@ describe("LogflareHttpClient", () => {
         )
     })
 
-    let consoleLogData = ""
-    const storeLog = (inputs) => (consoleLogData += inputs)
     it("prints to console on error", async () => {
         const errorResponse = {message: "Schema validation error"}
 
-        console["error"] = jest.fn(storeLog)
         global.fetch = jest.fn(() =>
             Promise.resolve({
                 json: () => Promise.resolve(errorResponse),
@@ -72,10 +84,38 @@ describe("LogflareHttpClient", () => {
         const le = {message: "info log msg", metadata: {p1: "v1"}}
 
         await httpClient.addLogEvent(le)
-        expect(consoleLogData).toBe(
+        expect(consoleErrorData[0]).toBe(
             `Logflare API request failed with 406 status: ${JSON.stringify(
                 errorResponse
             )}`
         )
+    })
+
+    it("invoke onError callback on error", async () => {
+        const errorResponse = {message: "Schema validation error"}
+
+        global.fetch = jest.fn(() =>
+            Promise.resolve({
+                json: () => Promise.resolve(errorResponse),
+                ok: false,
+                status: 406,
+            })
+        )
+
+        const le = {message: "info log msg", metadata: {p1: "v1"}}
+
+        await httpClientOnError.addLogEvent(le)
+        const [message, payload, err] = consoleErrorData
+        expect(message).toBe(
+            `Logflare API request failed with 406 status: ${JSON.stringify(
+                errorResponse
+            )}`
+        )
+        expect(onErrorCallback).toHaveBeenCalledTimes(1)
+        expect(payload).toStrictEqual({
+            batch: [le],
+        })
+        expect(err.message).toMatch(/Network response was not ok for/)
+        expect(err.data).toBe(errorResponse)
     })
 })


### PR DESCRIPTION
* Adds an `onError` option which accepts a callback function for error handling purposes 
* This will be very useful for handling retries on the client 
* This is a non-breaking change since `onError` is an optional parameter and is only invoked if it's defined