### PR TITLE
chore: add prod package publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,7 +19,7 @@ jobs:
       - run: yarn test
       - run: yarn build
       - name: Publish production package to npm
-        run: yarn publish --access public --tag dev --new-version $(npm info . version)
+        run: yarn publish --access public --tag latest --new-version $(npm info . version)
         env:
           CI: true
           NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,9 +1,7 @@
-name: main workflow
+name: Publish to npm registry (manual)
 
 on:
-  push:
-    branches:
-      - master
+  workflow_dispatch:
 
 jobs:
   build:
@@ -20,8 +18,8 @@ jobs:
       - run: yarn
       - run: yarn test
       - run: yarn build
-      - name: Publish dev package to npm
-        run: yarn publish --access public --tag dev --new-version $(npm info . version)-$(echo ${GITHUB_SHA} | cut -c1-8)
+      - name: Publish production package to npm
+        run: yarn publish --access public --tag dev --new-version $(npm info . version)
         env:
           CI: true
           NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}


### PR DESCRIPTION
This PR adds in a new workflow that enables maintainers to publish new versions to the npm registry. It must be triggered manually.

