### PR TITLE
chore: add vsn script for adding version numberr based on package.json

### DIFF
--- a/.github/workflows/publish-dev.yml
+++ b/.github/workflows/publish-dev.yml
@@ -1,4 +1,4 @@
-name: main workflow
+name: Publish dev package
 
 on:
   push:
@@ -21,7 +21,7 @@ jobs:
       - run: yarn test
       - run: yarn build
       - name: Publish dev package to npm
-        run: yarn publish --access public --tag dev --new-version $(npm info . version)-$(echo ${GITHUB_SHA} | cut -c1-8)
+        run: yarn publish --access public --tag dev --new-version $(npm run vsn)-$(echo ${GITHUB_SHA} | cut -c1-8)
         env:
           CI: true
           NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,7 +19,7 @@ jobs:
       - run: yarn test
       - run: yarn build
       - name: Publish production package to npm
-        run: yarn publish --access public --tag latest --new-version $(npm info . version)
+        run: yarn publish --access public --tag latest --new-version $(npm run vsn)
         env:
           CI: true
           NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "build": "tsc",
     "test": "jest",
     "test.watch": "jest --watch",
-    "vsn": "node -e \"console.log(require('./package.json').version);\"",
+    "vsn": "node -e \"console.log(require('./package.json').version);\""
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
   "scripts": {
     "build": "tsc",
     "test": "jest",
-    "test.watch": "jest --watch"
+    "test.watch": "jest --watch",
+    "vsn": "node -e \"console.log(require('./package.json').version);\"",
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This adds a `npm run vsn` script to retrieve the current package version as per `package.json`, which should be the value used for publishing packages.

It also updates the workflow files and renames `main.yml` to a more self-documenting file name.