### PR TITLE
chore: fix dist gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,4 +22,4 @@ jspm_packages/
 # JetBrains IDEA
 .idea/
 
-dist/
+dist


### PR DESCRIPTION
Fixes the path for `dist` in gitignore