### PR TITLE
chore: explicitly whitelist npm package files

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,8 @@
         "logging"
     ],
     "main": "dist/main.js",
+
+  "files": ["/dist", "/src"],
     "license": "MIT",
     "dependencies": {},
     "devDependencies": {


### PR DESCRIPTION
A hopeful fix for npm packaging issues